### PR TITLE
Add script to install challenge repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .env
 dist
+
+install.js

--- a/README.md
+++ b/README.md
@@ -1,7 +1,29 @@
 # ETH Tech Tree Challenge Grader
+
 This express server application is used to grade submitted challenges from the ETH Tech Tree
 
-## Get Started
-First install all the dependencies by running `yarn install`.
+## Getting Started
 
-Then you can run `yarn dev` to watch for changes as you develope.
+1. Download the repo
+
+```
+git clone https://github.com/BuidlGuidl/eth-tech-tree-backend.git
+```
+
+2. Install dependencies
+
+```
+yarn install
+```
+
+3. Install challenge folders where tests will be executed
+
+```
+yarn install:challenges
+```
+
+4. Start the server at `localhost:3000`
+
+```
+yarn dev
+```

--- a/challenges.json
+++ b/challenges.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "challenge",
+    "level": 1,
+    "name": "token-wrapper-weth",
+    "label": "Token Wrapper - WETH",
+    "github": "https://github.com/BuidlGuidl/eth-tech-tree-challenges.git",
+    "testHash": "cdef2b9c0051c45a8ce2c1ec14a7446419496a018a6dc114735cce9de3a4f249",
+    "contractName": "WrappedETH.sol",
+    "testFileName": "WrappedETH.t.sol",
+    "tags": ["DeFi"]
+  }
+]

--- a/install.ts
+++ b/install.ts
@@ -1,0 +1,53 @@
+import * as fs from "fs/promises";
+import { exec as execCb } from "child_process";
+import { promisify } from "util";
+const exec = promisify(execCb);
+
+interface Challenge {
+  name: string;
+  github: string;
+}
+
+const fetchChallenges = async (): Promise<Challenge[]> => {
+  const data = await fs.readFile("challenges.json", { encoding: "utf8" });
+  return JSON.parse(data);
+};
+
+async function executeCommand(command: string): Promise<void> {
+  const { stdout, stderr } = await exec(command);
+  if (stderr) {
+    console.error(`stderr: ${stderr}\n`);
+  }
+  console.log(`stdout: ${stdout}\n`);
+}
+
+const setupChallenge = async (challenge: Challenge): Promise<void> => {
+  try {
+    const path = `./${challenge.name}`;
+    const exists = await fs
+      .access(path)
+      .then(() => true)
+      .catch(() => false);
+
+    if (!exists) {
+      console.log(`👯...CLONING ${challenge.name}...👯`);
+      const cloneBranch = `git clone -b ${challenge.name} ${challenge.github} ${challenge.name}`;
+      await executeCommand(cloneBranch);
+    }
+
+    console.log(`🛠️...UPDATING ${challenge.name}...🛠️`);
+    const updateChallenge = `cd ${challenge.name} && git pull && yarn install`;
+    await executeCommand(updateChallenge);
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+const main = async (): Promise<void> => {
+  const challenges = await fetchChallenges();
+  for (const challenge of challenges) {
+    await setupChallenge(challenge);
+  }
+};
+
+main();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "tsc",
     "start": "tsx index.ts",
     "dev": "tsx watch index.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "install:challenges": "tsc install.ts && node install.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Closes #5 

### Summary
- Converted `install.js` script from `speedrun-grader` to typescript
- Added challenges.json with `github` property pointing at `https://github.com/BuidlGuidl/eth-tech-tree-challenges.git`
- Updated README with `yarn install:challenges` step