### PR TITLE
Add contract name to path

### DIFF
--- a/packages/server/utils/contract.ts
+++ b/packages/server/utils/contract.ts
@@ -80,7 +80,8 @@ export const testChallengeSubmission = async (config: SubmissionConfig) => {
   try {
     console.log("🧪 Testing challenge submission...");
     const path = `${__dirname}/../challenges/${challenge.name}`;
-    const contractPath = `download-${contractAddress}.sol`;
+    const contractName = challenge.contractName.replace(".sol", "");
+    const contractPath = `download-${contractAddress}.sol:${contractName}`;
     const testCommand = `cd ${path} && CONTRACT_PATH="${contractPath}" yarn foundry:test`;
     const { stdout, stderr } = await execute(testCommand);
     const removeContractCommand = `rm -f ${path}/packages/foundry/contracts/download-${contractAddress}.sol`;


### PR DESCRIPTION
A user tried submitting a contract that had an interface and contract defined in the source. Our backend was not ready to handle this since it is just looking for the newly downloaded file. This PR adds the contract name to the path so that even if multiple contracts or interfaces exist in the source, it will narrow it down to the correct one.