### PR TITLE
capture new user events

### DIFF
--- a/packages/server/services/user.ts
+++ b/packages/server/services/user.ts
@@ -54,8 +54,10 @@ export const createUser = async (
     ens = await getEnsName(address) as string;
   }
   const installLocations = { location, device };
+  // This returns the document before the update
   const doc = await User.findOneAndUpdate({ address }, { address, ens, $push: { installLocations } }, { upsert: true });
-  const isNew = !!doc?.isNew;
+  // If it is null then this user was created for the first time
+  const isNew = !doc;
   const user = await User.findOne({ address }, "-_id -__v");
   return { isNew, user: user as IUser };
 }


### PR DESCRIPTION
The upsert was returning null when a new entry was added so this change helps to correctly identify if a new user was added.

"By default, findOneAndUpdate() returns the document as it was before update was applied."
https://github.com/Automattic/mongoose/blob/master/docs/tutorials/findoneandupdate.md#getting-started