### PR TITLE
Allow null ENS

### DIFF
--- a/packages/server/utils/middleware.ts
+++ b/packages/server/utils/middleware.ts
@@ -30,8 +30,8 @@ export const validateChallengeSubmission = [
 ];
 
 export const validateNewUser = [
-  body("address").optional().isEthereumAddress().withMessage("Invalid Ethereum address"),
-  body("ens").optional().isString().withMessage("Invalid ENS name"),
+  body("address").optional({ nullable: true }).isEthereumAddress().withMessage("Invalid Ethereum address"),
+  body("ens").optional({ nullable: true }).isString().withMessage("Invalid ENS name"),
   (req: Request, res: Response, next: NextFunction) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {


### PR DESCRIPTION
We had a user report that they couldn't sign in. The issue was that they already existed in the db but they had no ENS so the db entry populated a null value for ENS before it sent the createUser request. Our API doesn't like null ENS, until now.