### PR TITLE
Ens helper endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Before you begin, you need to install the following tools:
 - GET `/users` → List users (summary)
 - GET `/user/:identifier` → Fetch user by address or ENS
 - GET `/leaderboard` → Leaderboard data
+- GET `/ens/:name` → Fetch address from ENS if it can be resolved
 - GET `/testnets` → Supported testnets configured on the server
 - POST `/submit` → Submit a challenge run
 

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -16,6 +16,7 @@ import {
   SUPPORTED_CHAINS,
 } from "./utils";
 import { fetchChallenge, fetchChallenges } from "./services/challenge";
+import { getEnsAddress } from "./services/ens";
 import { fetchUserWithChallengeAtAddress, fetchUser, createUser, updateUserChallengeSubmission, fetchAllUsers } from "./services/user";
 import { parseTestResults } from "./utils/parseTestResults";
 import { getLeaderboard } from "./services/leaderboard";
@@ -189,6 +190,26 @@ export const startServer = async () => {
       }
     }
   });
+
+  /**
+   * Resolve an ENS name to an address
+   */
+  app.get("/ens/:name", async (req: Request, res: Response) => {
+    console.log("GET /ens/:name \n", req.params);
+    const ensName = req.params.name;
+    try {
+      const address = await getEnsAddress(ensName);
+      return res.json({ address });
+    } catch (e) {
+      console.error(e);
+      if (e instanceof Error) {
+        return res.status(500).json({ error: e.message });
+      } else {
+        return res.status(500).json({ error: "Unexpected error occurred" });
+      }
+    }
+  });
+
   if (SKIP_TEST_EXISTS_CHECK) {
     console.log("WARN: Set up to skip the test exists check");
   }


### PR DESCRIPTION
NOTE: This backend PR was made to support [this CLI PR](https://github.com/BuidlGuidl/eth-tech-tree/pull/123)

## Why
The CLI repo has a bug with new username validation, causing it to crash with ENS names that don't resolve to an address. To fix it, the CLI needs access to a simple ENS name lookup.

## How
- Add an `/ens/:name` endpoint that basically just retruns `client.getEnsAddress({ name })`