### PR TITLE
use a regex to find the correct path instead of guessing

### DIFF
--- a/packages/server/utils/contract.ts
+++ b/packages/server/utils/contract.ts
@@ -68,10 +68,12 @@ const parseSourceCode = (sourceCode: string, challenge: any) => {
       // Option 2. An almost valid JSON
       // Remove the initial and final { }
       const validJson = JSON.parse(sourceCode.substring(1).slice(0, -1));
-      return (
-        validJson?.sources[`contracts/${challenge.contractName}`]?.content ??
-        validJson?.sources[`./contracts/${challenge.contractName}`]?.content
-      );
+      const sources = validJson?.sources ?? {};
+      const contractFile = challenge.contractName;
+      const escaped = contractFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const pattern = new RegExp(`(?:^|[\\\\/])${escaped}$`);
+      const matchedKey = Object.keys(sources).find((key) => pattern.test(key));
+      return matchedKey ? sources[matchedKey]?.content : undefined;
     } else {
       // Option 1. A string
       return sourceCode;


### PR DESCRIPTION
A user was trying to submit a contract and for some unknown reason the sources did not contain the expected `contracts/` or `./contracts` path and instead had a `src/` path. By using a RegEx we can get the correct file no matter what the path looks like.

I wonder if the user moved the contracts to a different file structure and that would cause this. In any case this should make it work regardless.